### PR TITLE
Update typedefs.py

### DIFF
--- a/config/typedefs.py
+++ b/config/typedefs.py
@@ -27,7 +27,6 @@ class ModelConfig:
 
     name: str
     model_musicgen_path: str
-    laion_clap_path: str
     max_sequence_length: int
     hidden_size: int
     num_attention_heads: int


### PR DESCRIPTION
Eliminado `laion_clap_path` de model config porque ya no tenemos referencia en `config.yaml` y no estamos guardando el modelo en dvc. 

Cuando se instanciaba config generaba errores.